### PR TITLE
feat: agregar resumen de historia y consulta de paquetes disponibles por paciente

### DIFF
--- a/src/controllers/historyquotes.controller.js
+++ b/src/controllers/historyquotes.controller.js
@@ -105,5 +105,19 @@ module.exports = {
         } catch (e) {
             res.status(400).send(response.set(500, e.message));
         }
+    },
+
+    async getSummaryByHistoryNumber(req, res) {
+        try {
+            const data = await historyService.getSummaryByHistoryNumber(req.params.id);
+
+            if (!data) {
+                return res.send(response.set(404, 'No existe la historia clínica'));
+            }
+
+            res.send(response.set(200, 'Resumen de historia clínica', data));
+        } catch (e) {
+            res.status(400).send(response.set(500, e.message));
+        }
     }
 };

--- a/src/controllers/package.controller.js
+++ b/src/controllers/package.controller.js
@@ -112,5 +112,14 @@ module.exports = {
         } catch (error) {
             res.status(400).send(response.set(500, error.message));
         }
+    },
+
+    async getAvailablePackagesByPatient(req, res) {
+        try {
+            const packages = await packagesService.getAvailablePackagesByPatient(req.params.id);
+            res.send(response.set(200, 'Paquetes con citas disponibles', packages));
+        } catch (error) {
+            res.status(400).send(response.set(500, error.message));
+        }
     }
 };

--- a/src/routes/historyquote.route.js
+++ b/src/routes/historyquote.route.js
@@ -9,5 +9,6 @@ router.post('/create', historyController.create);
 router.put('/update/:id', historyController.update);
 router.get('/export-pdf/:id', historyController.exportPdf);
 router.get('/get-by-quote/:id', historyController.getByQuote);
+router.get('/get-summary-by-history-number/:id', historyController.getSummaryByHistoryNumber);
 
 module.exports = router;

--- a/src/routes/packages.route.js
+++ b/src/routes/packages.route.js
@@ -12,6 +12,7 @@ const { verifyToken } = require('../middlewares/auth.middleware');
 
 router.post('/create', packagesController.createPackage);
 router.get('/get-by-patient/:id', packagesController.getPackagesByPatient);
+router.get('/get-available-by-patient/:id', packagesController.getAvailablePackagesByPatient);
 router.get('/get-packages', packagesController.getAllPackages);
 router.get('/get/:id', packagesController.getPackageById);
 router.put('/close/:id', packagesController.closePackage);

--- a/src/services/historyquotes.service.js
+++ b/src/services/historyquotes.service.js
@@ -1,5 +1,5 @@
 const { PDFDocument, StandardFonts, rgb } = require('pdf-lib');
-const { HistoryQuote, Cie10, Quotes, Packages, Patient, sequelize } = require('../models');
+const { HistoryQuote, Cie10, Quotes, Packages, Patient, Payment, sequelize } = require('../models');
 
 const ANTECEDENT_FIELDS = [
     'antecedentes',
@@ -439,5 +439,57 @@ module.exports = {
                 }
             ]
         });
+    },
+
+    async getSummaryByHistoryNumber(historyNumber) {
+        const history = await HistoryQuote.findByPk(historyNumber, {
+            include: [
+                {
+                    model: Quotes,
+                    as: 'Quotes',
+                    attributes: ['id', 'fecha_agendamiento', 'horario_inicio', 'motivo', 'numero_sesion', 'pagado', 'id_profesional', 'id_paquetes'],
+                    include: [
+                        {
+                            model: Packages,
+                            as: 'package',
+                            attributes: ['id'],
+                            include: [
+                                {
+                                    model: Patient,
+                                    as: 'patient',
+                                    attributes: ['nombre', 'apellido']
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        });
+
+        if (!history) return null;
+
+        const quote = history.Quotes;
+        if (!quote) {
+            throw new Error('La historia no tiene una cita asociada');
+        }
+
+        const payment = await Payment.findOne({
+            where: { id_cita: quote.id },
+            order: [['fecha_pago', 'DESC']]
+        });
+
+        return {
+            numero_historia: history.id,
+            nombre_paciente: `${quote.package?.patient?.nombre || ''} ${quote.package?.patient?.apellido || ''}`.trim(),
+            id_profesional: quote.id_profesional,
+            fecha_cita: quote.fecha_agendamiento,
+            hora_cita: quote.horario_inicio,
+            id_paquete: quote.id_paquetes,
+            motivo: quote.motivo,
+            numero_sesion: quote.numero_sesion,
+            estado_pago: quote.pagado ? 'PAGADO' : 'PENDIENTE',
+            metodo_pago: payment?.metodo_pago || null,
+            fecha_ultimo_pago: payment?.fecha_pago || null
+        };
     }
 };

--- a/src/services/packages.service.js
+++ b/src/services/packages.service.js
@@ -118,5 +118,55 @@ module.exports = {
             if (ownTransaction) await t.rollback();
             throw err;
         }
+    },
+
+    async getAvailablePackagesByPatient(id_pacientes) {
+        const packages = await Packages.findAll({
+            where: { id_pacientes, id_estado_citas: 1 },
+            include: [
+                {
+                    model: AttentionPackages,
+                    as: 'attentionPackage',
+                    attributes: ['descripcion', 'cantidad_sesiones']
+                },
+                {
+                    model: Professional,
+                    as: 'professional',
+                    attributes: ['id', 'nombre', 'apellido']
+                },
+                {
+                    model: Cie10,
+                    as: 'secondaryDiagnosis',
+                    attributes: ['codigo', 'descripcion']
+                },
+                {
+                    model: Quotes,
+                    attributes: ['id']
+                }
+            ]
+        });
+
+        return packages
+            .map((pkg) => {
+                const sesionesTotales = pkg.attentionPackage?.cantidad_sesiones || 0;
+                const sesionesUsadas = pkg.Quotes?.length || 0;
+                const sesionesDisponibles = Math.max(sesionesTotales - sesionesUsadas, 0);
+
+                return {
+                    id_paquete: pkg.id,
+                    sesiones_disponibles: sesionesDisponibles,
+                    sesiones_totales: sesionesTotales,
+                    sesiones_usadas: sesionesUsadas,
+                    tipo_paquete: pkg.attentionPackage?.descripcion || null,
+                    id_profesional: pkg.professional?.id || null,
+                    profesional: pkg.professional
+                        ? `${pkg.professional.nombre || ''} ${pkg.professional.apellido || ''}`.trim()
+                        : null,
+                    motivo_secundario: pkg.secondaryDiagnosis
+                        ? `${pkg.secondaryDiagnosis.codigo} - ${pkg.secondaryDiagnosis.descripcion}`
+                        : null
+                };
+            })
+            .filter((pkg) => pkg.sesiones_disponibles > 0);
     }
 };


### PR DESCRIPTION
### Motivation
- Añadir un endpoint que permita consultar una historia clínica por número de historia y devolver un resumen plano con nombre del paciente, id del profesional, fecha/hora de la cita, id del paquete, motivo, número de sesión y estado de pago. 
- Añadir un endpoint que consulte por paciente los paquetes que aún tienen sesiones/citas disponibles y devuelva datos en un objeto simple y sin anidamientos profundos.

### Description
- Se añadió `getSummaryByHistoryNumber(historyNumber)` en `src/services/historyquotes.service.js` que incluye `Payment` y consulta `HistoryQuote -> Quotes -> Packages -> Patient` para devolver un objeto plano con `numero_historia`, `nombre_paciente`, `id_profesional`, `fecha_cita`, `hora_cita`, `id_paquete`, `motivo`, `numero_sesion`, `estado_pago` y datos del último pago (`metodo_pago`, `fecha_ultimo_pago`).
- Se añadió el controlador `getSummaryByHistoryNumber` en `src/controllers/historyquotes.controller.js` y la ruta `GET /history/get-summary-by-history-number/:id` en `src/routes/historyquote.route.js`.
- Se añadió `getAvailablePackagesByPatient(id_pacientes)` en `src/services/packages.service.js` que filtra paquetes activos del paciente, calcula `sesiones_totales`, `sesiones_usadas` y `sesiones_disponibles`, devuelve objetos planos (`id_paquete`, `sesiones_disponibles`, `sesiones_totales`, `sesiones_usadas`, `tipo_paquete`, `id_profesional`, `profesional`, `motivo_secundario`) y solo retorna paquetes con `sesiones_disponibles > 0`.
- Se añadió el controlador `getAvailablePackagesByPatient` en `src/controllers/package.controller.js` y la ruta `GET /packages/get-available-by-patient/:id` en `src/routes/packages.route.js`.

### Testing
- Se verificó la sintaxis de los archivos modificados con `node --check` sobre `src/services/historyquotes.service.js`, `src/controllers/historyquotes.controller.js`, `src/routes/historyquote.route.js`, `src/services/packages.service.js`, `src/controllers/package.controller.js` y `src/routes/packages.route.js`, y la comprobación fue exitosa. 
- Se realizó un commit con los cambios aplicados y no quedaron cambios pendientes en `git status` después del commit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8fcaa7494832b9623c68b35537ff6)