### PR TITLE
Add pagination metadata to patient listing

### DIFF
--- a/docs/ENDPOINTS_NEGOCIO_LLM.md
+++ b/docs/ENDPOINTS_NEGOCIO_LLM.md
@@ -220,6 +220,12 @@ Retorna pacientes con `estado=true` e incluye diagnóstico principal (`diagnosis
 
 - `200`
 
+Query params opcionales:
+
+- `search`: busca por `nombre`, `apellido` o `num_doc`.
+- `page`: página solicitada; por defecto `1`.
+- `limit`: cantidad de registros por página; por defecto `20`.
+
 ```json
 {
   "status": 200,
@@ -239,7 +245,15 @@ Retorna pacientes con `estado=true` e incluye diagnóstico principal (`diagnosis
         "descripcion": "Lumbalgia"
       }
     }
-  ]
+  ],
+  "pagination": {
+    "total": 57,
+    "page": 1,
+    "limit": 20,
+    "totalPages": 3,
+    "hasNextPage": true,
+    "hasPreviousPage": false
+  }
 }
 ```
 

--- a/docs/PATIENT_PAGINATION_FRONT.md
+++ b/docs/PATIENT_PAGINATION_FRONT.md
@@ -1,0 +1,95 @@
+# Paginación para `GET /patient/get-patients`
+
+No es necesario agregar un endpoint nuevo. El endpoint existente `GET /patient/get-patients` ya recibe los parámetros que envía el front:
+
+```ts
+patientService.getAll(search?: string, page = 1, limit = 20)
+```
+
+## Endpoint a usar
+
+```http
+GET /patient/get-patients?page=1&limit=20&search=ana
+```
+
+- `page`: número de página. Si no llega o llega inválido, el backend usa `1`.
+- `limit`: cantidad de pacientes por página. Si no llega o llega inválido, el backend usa `20`.
+- `search`: opcional. Busca coincidencias en `nombre`, `apellido` o `num_doc`.
+
+## Respuesta del backend
+
+El arreglo de pacientes queda en `response`, por compatibilidad con el tipado actual del front (`BackendResponse<Patient[]>`). La metadata de paginación queda en una propiedad hermana llamada `pagination`.
+
+```json
+{
+  "status": 200,
+  "message": "Listado de Pacientes",
+  "response": [
+    {
+      "id": 1,
+      "tipo_doc": "CC",
+      "num_doc": "123456",
+      "nombre": "Ana",
+      "apellido": "Pérez",
+      "estado": true
+    }
+  ],
+  "pagination": {
+    "total": 57,
+    "page": 1,
+    "limit": 20,
+    "totalPages": 3,
+    "hasNextPage": true,
+    "hasPreviousPage": false
+  }
+}
+```
+
+## Ajuste recomendado en el front
+
+Si el front solo necesita el listado, puede seguir usando:
+
+```ts
+return res.data.response;
+```
+
+Si también necesita pintar controles de paginación, conviene ampliar el modelo genérico para aceptar `pagination` como opcional:
+
+```ts
+export interface Pagination {
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+}
+
+export interface BackendResponse<T> {
+  status: number;
+  message: string;
+  response: T;
+  pagination?: Pagination;
+}
+```
+
+Y en el servicio puedes devolver ambos valores si la pantalla lo requiere:
+
+```ts
+const res = await api.get<BackendResponse<Patient[]>>(`/patient/get-patients?${params}`);
+return {
+  patients: res.data.response,
+  pagination: res.data.pagination,
+};
+```
+
+## Remapeo aplicado
+
+Antes el backend retornaba la paginación dentro de `response` como un objeto con forma `{ data, total, page, limit, totalPages }`. Eso rompía el contrato `BackendResponse<Patient[]>`, porque `response` dejaba de ser un arreglo.
+
+Ahora el backend remapea internamente el resultado a:
+
+- `response`: `Patient[]`
+- `pagination`: metadata de paginación
+
+Así el endpoint existente cubre búsqueda y paginación sin crear rutas adicionales.

--- a/src/controllers/patient.controller.js
+++ b/src/controllers/patient.controller.js
@@ -31,7 +31,12 @@ const getAllPatients = async (req, res) => {
     });
 
     res.status(200).send(
-      response.set(200, 'Listado de Pacientes', patients)
+      response.paginated(
+        200,
+        'Listado de Pacientes',
+        patients.data,
+        patients.pagination
+      )
     );
 
   } catch (error) {

--- a/src/models/Pagination.models.js
+++ b/src/models/Pagination.models.js
@@ -1,0 +1,33 @@
+const parsePositiveInteger = (value, fallback) => {
+  const parsed = Number.parseInt(value, 10);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+};
+
+class Pagination {
+  constructor({ total = 0, page = 1, limit = 20 }) {
+    const safeTotal = Number.isFinite(Number(total)) ? Number(total) : 0;
+    const safePage = parsePositiveInteger(page, 1);
+    const safeLimit = parsePositiveInteger(limit, 20);
+    const totalPages = safeLimit > 0 ? Math.ceil(safeTotal / safeLimit) : 0;
+
+    this.total = safeTotal;
+    this.page = safePage;
+    this.limit = safeLimit;
+    this.totalPages = totalPages;
+    this.hasNextPage = safePage < totalPages;
+    this.hasPreviousPage = safePage > 1 && totalPages > 0;
+  }
+
+  static normalize({ page = 1, limit = 20 } = {}) {
+    return {
+      page: parsePositiveInteger(page, 1),
+      limit: parsePositiveInteger(limit, 20)
+    };
+  }
+
+  static set(args = {}) {
+    return new Pagination(args);
+  }
+}
+
+module.exports = Pagination;

--- a/src/models/Response.models.js
+++ b/src/models/Response.models.js
@@ -1,8 +1,12 @@
 class Response {
-    constructor(status, message, response) {
+    constructor(status, message, response, pagination = null) {
       this.status = status;
       this.message = message;
       this.response = response;
+
+      if (pagination) {
+        this.pagination = pagination;
+      }
     }
   
     static set(...args) {
@@ -15,6 +19,10 @@ class Response {
       } else if (args.length === 3) {
         return new Response(args[0], args[1], args[2]);
       }
+    }
+
+    static paginated(status, message, response, pagination) {
+      return new Response(status, message, response, pagination);
     }
   }
   

--- a/src/routes/patient.route.js
+++ b/src/routes/patient.route.js
@@ -16,6 +16,33 @@ const { verifyToken } = require('../middlewares/auth.middleware');
  * @swagger
  * components:
  *   schemas:
+ *     Pagination:
+ *       type: object
+ *       properties:
+ *         total:
+ *           type: integer
+ *           description: Total de registros encontrados
+ *           example: 57
+ *         page:
+ *           type: integer
+ *           description: Página actual
+ *           example: 1
+ *         limit:
+ *           type: integer
+ *           description: Registros solicitados por página
+ *           example: 20
+ *         totalPages:
+ *           type: integer
+ *           description: Total de páginas disponibles
+ *           example: 3
+ *         hasNextPage:
+ *           type: boolean
+ *           description: Indica si existe una página siguiente
+ *           example: true
+ *         hasPreviousPage:
+ *           type: boolean
+ *           description: Indica si existe una página anterior
+ *           example: false
  *     Patient:
  *       type: object
  *       required:
@@ -64,19 +91,51 @@ const { verifyToken } = require('../middlewares/auth.middleware');
  * /patient/get-patients:
  *   get:
  *     summary: Obtiene toda la información de los pacientes
- *     description: Devuelve una lista de todos los pacientes registrados en el sistema.
+ *     description: Devuelve una lista paginada de pacientes activos registrados en el sistema.
  *     tags: [Patient]
  *     security:
  *       - bearerAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: search
+ *         required: false
+ *         schema:
+ *           type: string
+ *         description: Texto para buscar por nombre, apellido o número de documento
+ *       - in: query
+ *         name: page
+ *         required: false
+ *         schema:
+ *           type: integer
+ *           default: 1
+ *         description: Número de página solicitada
+ *       - in: query
+ *         name: limit
+ *         required: false
+ *         schema:
+ *           type: integer
+ *           default: 20
+ *         description: Cantidad de pacientes por página
  *     responses:
  *       200:
  *         description: Lista de pacientes.
  *         content:
  *           application/json:
  *             schema:
- *               type: array
- *               items:
- *                 $ref: '#/components/schemas/Patient'
+ *               type: object
+ *               properties:
+ *                 status:
+ *                   type: integer
+ *                   example: 200
+ *                 message:
+ *                   type: string
+ *                   example: Listado de Pacientes
+ *                 response:
+ *                   type: array
+ *                   items:
+ *                     $ref: '#/components/schemas/Patient'
+ *                 pagination:
+ *                   $ref: '#/components/schemas/Pagination'
  */
 router.get('/get-patients', patientController.getAllPatients);
 

--- a/src/services/patient.service.js
+++ b/src/services/patient.service.js
@@ -1,5 +1,6 @@
 const { Op } = require('sequelize');
 const { Patient, Cie10 } = require('../models');
+const Pagination = require('../models/Pagination.models');
 
 const ensureDiagnosisExists = async (id_cie, label = 'principal') => {
   if (!id_cie) return;
@@ -40,7 +41,11 @@ const getAllPatients = async ({
   limit = 20
 }) => {
 
-  const offset = (page - 1) * limit;
+  const { page: normalizedPage, limit: normalizedLimit } = Pagination.normalize({
+    page,
+    limit
+  });
+  const offset = (normalizedPage - 1) * normalizedLimit;
 
   const where = {
     estado: true
@@ -70,17 +75,18 @@ const getAllPatients = async ({
   const { rows, count } = await Patient.findAndCountAll({
     where,
     include: patientInclude,
-    limit,
+    limit: normalizedLimit,
     offset,
     order: [['id', 'DESC']]
   });
 
   return {
     data: rows,
-    total: count,
-    page,
-    limit,
-    totalPages: Math.ceil(count / limit)
+    pagination: Pagination.set({
+      total: count,
+      page: normalizedPage,
+      limit: normalizedLimit
+    })
   };
 };
 


### PR DESCRIPTION
### Motivation
- Mantener la compatibilidad con el frontend (`BackendResponse<Patient[]>`) mientras se añade soporte de paginación en `GET /patient/get-patients` sin crear un endpoint nuevo.  
- Normalizar y validar los parámetros `page` y `limit` para evitar respuestas inconsistentes al paginar.  
- Documentar el contrato nuevo para que el front sepa leer `response` (array de pacientes) y `pagination` (metadata).

### Description
- Añadí un modelo reusable `Pagination` con normalización y metadatos (`total`, `page`, `limit`, `totalPages`, `hasNextPage`, `hasPreviousPage`) en `src/models/Pagination.models.js`.  
- Extendí el modelo de respuesta en `src/models/Response.models.js` con `response.paginated(...)` que admite una propiedad opcional `pagination`.  
- Normalicé el paginado en el servicio y remapeé la respuesta: `src/services/patient.service.js` ahora devuelve `{ data, pagination }` y `src/controllers/patient.controller.js` usa `response.paginated(200, ..., data, pagination)` para mantener `response` como `Patient[]`.  
- Actualicé la documentación Swagger en `src/routes/patient.route.js` (parámetros `search`, `page`, `limit` y esquema `Pagination`) y añadí `docs/PATIENT_PAGINATION_FRONT.md` explicando el contrato esperado por el front y actualicé `docs/ENDPOINTS_NEGOCIO_LLM.md` con el ejemplo de respuesta paginada.

### Testing
- Ejecuté comprobaciones de sintaxis con `node --check` sobre `src/models/Pagination.models.js`, `src/models/Response.models.js`, `src/services/patient.service.js`, `src/controllers/patient.controller.js` y `src/routes/patient.route.js`, y todas pasaron correctamente.  
- Verifiqué que no haya errores de diff con `git diff --check`, que devolvió sin problemas.  
- Se creó el commit con los cambios principales (`Add paginated patient list response`) y la PR refleja los archivos: `src/models/Pagination.models.js`, `src/models/Response.models.js`, `src/services/patient.service.js`, `src/controllers/patient.controller.js`, `src/routes/patient.route.js`, y documentación en `docs/`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00b41f4e548320a6cdb704d10278c7)