### PR TITLE
Add reports module, pagination and several frontend-compatible endpoints (CIE10 update, payments appointment summary, history by patient, packages assigned, quotes pagination)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # Back_FisenT
-Backend para el proyecto de fisen
+
+Backend para el proyecto de FisenT.
+
+## Documentación del contrato backend
+
+- `docs/ENDPOINTS_NEGOCIO_LLM.md`: documentación integral de endpoints, reglas de negocio, respuestas y requerimientos de reportes.
+- `docs/PATIENT_PAGINATION_FRONT.md`: contrato de paginación aplicado a pacientes y guía de compatibilidad frontend.
+- `docs/FRONT_BACKEND_GAPS_AND_REPORTS.md`: brechas detectadas en endpoints frontend/backend, paginación requerida y especificación del módulo Reports Page.

--- a/docs/ENDPOINTS_NEGOCIO_LLM.md
+++ b/docs/ENDPOINTS_NEGOCIO_LLM.md
@@ -16,6 +16,7 @@ Este backend cubre:
 - Registro de pagos (por paquete o por cita).
 - Login con JWT.
 - Gestión de profesionales (consulta).
+- Reportes y estadísticas agregadas para dashboard (requerimiento documentado; evita cálculos pesados en frontend).
 
 ## 2) Base URL y seguridad
 
@@ -29,6 +30,7 @@ Este backend cubre:
   - `/payments/*`
   - `/professionals/*`
   - `/cie10/*`
+  - `/reports/*`
 
 ### 2.1 Header de autenticación
 
@@ -304,6 +306,8 @@ Borrado lógico (`estado=false`).
 
 Devuelve catálogo de tipos de paquete (`atencion_paquetes`), no los paquetes asignados.
 
+> Implementado: soporta `page`, `limit`, `search` y metadata `pagination` manteniendo `response` como `AttentionPackage[]`.
+
 ### POST `/packages/create`
 
 Crea paquete para paciente.
@@ -327,7 +331,7 @@ Reglas:
 
 ### GET `/packages/get-by-patient/:id`
 
-Lista paquetes de un paciente, incluyendo:
+Lista paquetes asignados a un paciente, incluyendo:
 
 - `attentionPackage`
 - `statusPackage`
@@ -339,6 +343,21 @@ Lista paquetes de un paciente, incluyendo:
 
 Detalle de paquete con relaciones amplias (paciente, tipo, estado, profesional, CIE10 secundario, citas).
 
+### GET `/packages/get-available-by-patient/:id?quoteId=...`
+
+Lista paquetes activos del paciente con sesiones disponibles. Está orientado al selector de paquetes al crear/editar citas.
+
+Parámetros:
+
+- `:id`: ID del paciente.
+- `quoteId` opcional: ID de la cita actual en modo edición para no descontarla dos veces.
+
+Respuesta: `response` es un arreglo con `id_paquete`, sesiones disponibles/usadas/totales, tipo de paquete, profesional, motivo secundario y `tiene_cita_actual`.
+
+### GET `/packages/get-assigned?page=1&limit=20&search=...`
+
+Lista paquetes asignados a pacientes con paginación, búsqueda y filtros opcionales `id_paciente`, `id_profesional`, `id_estado_citas`. No confundir con `GET /packages/get-packages`, que devuelve catálogo de tipos.
+
 ### PUT `/packages/close/:id`
 
 Cierra paquete (`id_estado_citas = 3`).
@@ -347,7 +366,20 @@ Cierra paquete (`id_estado_citas = 3`).
 
 ### GET `/quotes/all`
 
-Lista todas las citas.
+Lista citas.
+
+> Implementado: soporta paginación y filtros sin romper compatibilidad:
+>
+> - `page` y `limit` para paginar.
+> - `search` para búsquedas textuales útiles para UI.
+> - `fecha` o rango `fechaInicio`/`fechaFin` para agenda.
+> - `id_profesional` para filtrar por profesional.
+> - `id_paciente` para filtrar por paciente vía paquete.
+> - Mantener `response` como `Appointment[]` y publicar metadata en `pagination`.
+>
+> Ejemplo: `GET /quotes/all?page=1&limit=20&fecha=2026-05-10&id_profesional=3`.
+>
+> Implementado: además de `PUT /quotes/update/:id`, existe alias compatible `PUT /quotes/:id`.
 
 ### GET `/quotes/all-attention-packages`
 
@@ -390,6 +422,12 @@ Parámetro:
 
 - `:id` = `id_profesional`
 - query `date` obligatoria
+
+### PUT `/quotes/update/:id`
+
+Actualiza una cita existente.
+
+> Compatibilidad frontend: también está disponible el alias `PUT /quotes/:id`.
 
 ### DELETE `/quotes/:id`
 
@@ -441,7 +479,11 @@ Exporta **DOCX** (aunque la ruta diga pdf) con `Content-Disposition: attachment;
 
 ### GET `/payments/`
 
-Lista todos los pagos.
+Lista pagos.
+
+> Implementado: soporta `page`, `limit`, `search`, `id_paquete`, `id_cita` y metadata `pagination` sin cambiar `response` (`Payment[]`). Evita que el frontend descargue todos los pagos para filtrar por paquete/cita.
+>
+> Ejemplo: `GET /payments/?page=1&limit=20&id_paquete=5&search=transferencia`.
 
 ### GET `/payments/:id`
 
@@ -475,6 +517,27 @@ Resumen de pagos de un paquete:
 ### GET `/payments/package-all-summary/:id`
 
 Igual al resumen anterior, pero agrega `pagos: []`.
+
+### GET `/payments/appointment-summary/:id`
+
+Resumen de pagos de una cita. La pantalla de pagos puede obtener estado de cuenta por cita sin calcularlo en cliente.
+
+Respuesta recomendada:
+
+```json
+{
+  "status": 200,
+  "message": "Resumen de pagos de la cita",
+  "response": {
+    "id_cita": 44,
+    "total_cita": 60000,
+    "total_abonado": 60000,
+    "saldo_pendiente": 0,
+    "estado_pago": "pagado",
+    "cantidad_abonos": 1
+  }
+}
+```
 
 ### POST `/payments/`
 
@@ -551,6 +614,8 @@ Elimina pago físicamente.
 
 Lista todos los profesionales.
 
+> Implementado: soporta `page`, `limit`, `search` y `pagination` manteniendo `response` como arreglo. Para rankings de reportes no usar este endpoint; usar `GET /reports/professionals/top`.
+
 ## 5.8 CIE10 (`/cie10`)
 
 ### POST `/cie10/create`
@@ -579,15 +644,362 @@ Consulta CIE10 con filtros:
 - `codigo` exacto (normalizado)
 - `q` búsqueda parcial en código o descripción
 
+> Implementado: soporta `page`, `limit` y `pagination` manteniendo `response` como `Cie10[]`.
+>
+> Ejemplo: `GET /cie10/all?q=lumbalgia&page=1&limit=20`.
+
 ### GET `/cie10/:id`
 
 Obtiene por ID.
+
+### PUT `/cie10/:id`
+
+Actualiza un código CIE10 existente. Normaliza `codigo`, valida duplicados y responde con contrato estándar.
+
+Body recomendado:
+
+```json
+{
+  "codigo": "M54.5",
+  "descripcion": "Lumbalgia"
+}
+```
 
 ### GET `/cie10/code/:code`
 
 Obtiene por código.
 
-## 6) Reglas transversales y consideraciones para un LLM
+## 6) Reportes y estadísticas (`/reports`) — requerimiento backend
+
+### Objetivo del módulo
+
+Mover la agregación de métricas desde el frontend hacia el backend. La página de reportes no debe ejecutar `getAll()` de pacientes, paquetes, citas, pagos y profesionales para luego hacer `reduce`, `filter`, `map` o `groupBy` en cliente.
+
+El backend debe retornar resúmenes y datasets ya agrupados, usando agregaciones SQL, filtros por fecha, joins optimizados y solo los campos necesarios.
+
+### Parámetros globales para endpoints de reportes
+
+Todos los endpoints de reportes deben soportar:
+
+- `period=week|month|quarter`
+- `startDate=YYYY-MM-DD` opcional
+- `endDate=YYYY-MM-DD` opcional
+
+Regla recomendada:
+
+- Si llegan `startDate` y `endDate`, tienen prioridad sobre `period`.
+- Si no llegan fechas, `period` calcula el rango relativo en backend.
+- Si no llega `period`, usar `month` como valor por defecto.
+
+### GET `/reports/dashboard` (prioridad alta)
+
+Retorna todas las métricas principales para cards, gráficas y resumen general del dashboard.
+
+Query params:
+
+- `period`
+- `startDate`
+- `endDate`
+
+Respuesta esperada:
+
+```json
+{
+  "status": 200,
+  "message": "Dashboard report",
+  "response": {
+    "patients": {
+      "active": 120,
+      "inactive": 15,
+      "total": 135
+    },
+    "appointments": {
+      "completed": 230,
+      "scheduled": 40,
+      "cancelled": 20,
+      "noShow": 10,
+      "attendanceRate": 88
+    },
+    "sessions": {
+      "completed": 480,
+      "pending": 120,
+      "total": 600,
+      "completionRate": 80
+    },
+    "revenue": {
+      "total": 25000000,
+      "byMonth": [
+        {
+          "month": "2026-01",
+          "amount": 5000000
+        }
+      ],
+      "byPaymentMethod": [
+        {
+          "method": "EFECTIVO",
+          "amount": 12000000
+        },
+        {
+          "method": "TRANSFERENCIA",
+          "amount": 8000000
+        }
+      ]
+    },
+    "packages": {
+      "total": 80,
+      "byType": [
+        {
+          "type": "REHABILITACION",
+          "count": 40
+        }
+      ],
+      "nearCompletion": [
+        {
+          "id": 1,
+          "nombre": "Paquete Rodilla",
+          "completionPercentage": 85,
+          "sesionesRealizadas": 17,
+          "cantidadSesiones": 20,
+          "paciente": {
+            "id": 5,
+            "nombres": "Ana",
+            "apellidos": "Perez"
+          }
+        }
+      ]
+    },
+    "professionals": {
+      "top": [
+        {
+          "id": 2,
+          "nombres": "Carlos",
+          "apellidos": "Lopez",
+          "appointments": 42
+        }
+      ]
+    },
+    "recentPayments": [
+      {
+        "id": 1,
+        "tipo": "ABONO",
+        "valor": 200000,
+        "metodo_pago": "EFECTIVO",
+        "fecha_pago": "2026-05-10T10:00:00"
+      }
+    ]
+  }
+}
+```
+
+### GET `/reports/revenue` (prioridad alta)
+
+Ingresos agrupados por mes para la gráfica de evolución mensual.
+
+Query params:
+
+- `period`
+- `startDate`
+- `endDate`
+
+Respuesta:
+
+```json
+{
+  "status": 200,
+  "message": "Revenue report",
+  "response": [
+    {
+      "month": "2026-01",
+      "amount": 5000000
+    }
+  ]
+}
+```
+
+### GET `/reports/appointments/status-distribution` (prioridad alta)
+
+Distribución de citas por estado para barras/progreso.
+
+Query params:
+
+- `period`
+- `startDate`
+- `endDate`
+
+Respuesta:
+
+```json
+{
+  "status": 200,
+  "message": "Appointment status distribution",
+  "response": {
+    "completed": 120,
+    "scheduled": 50,
+    "cancelled": 10,
+    "noShow": 5
+  }
+}
+```
+
+### GET `/reports/professionals/top` (prioridad media)
+
+Ranking de profesionales por cantidad de citas.
+
+Query params:
+
+- `limit=5`
+- `period`
+- `startDate`
+- `endDate`
+
+Respuesta:
+
+```json
+{
+  "status": 200,
+  "message": "Top professionals",
+  "response": [
+    {
+      "id": 1,
+      "nombres": "Juan",
+      "apellidos": "Perez",
+      "appointments": 45
+    }
+  ]
+}
+```
+
+### GET `/reports/packages/by-type` (prioridad media)
+
+Distribución de paquetes por tipo.
+
+Query params:
+
+- `period`
+- `startDate`
+- `endDate`
+
+Respuesta:
+
+```json
+{
+  "status": 200,
+  "message": "Packages by type",
+  "response": [
+    {
+      "type": "REHABILITACION",
+      "count": 30
+    }
+  ]
+}
+```
+
+### GET `/reports/packages/near-completion` (prioridad media)
+
+Paquetes próximos a terminar para alertas del dashboard.
+
+Query params:
+
+- `threshold=70`
+- `limit=5`
+- `period`
+- `startDate`
+- `endDate`
+
+Respuesta:
+
+```json
+{
+  "status": 200,
+  "message": "Packages near completion",
+  "response": [
+    {
+      "id": 1,
+      "nombre": "Rodilla",
+      "completionPercentage": 85,
+      "sesionesRealizadas": 17,
+      "cantidadSesiones": 20,
+      "paciente": {
+        "id": 5,
+        "nombres": "Ana",
+        "apellidos": "Perez"
+      }
+    }
+  ]
+}
+```
+
+### GET `/reports/payments/recent` (prioridad media)
+
+Feed de pagos recientes.
+
+Query params:
+
+- `limit=5`
+- `period`
+- `startDate`
+- `endDate`
+
+Respuesta:
+
+```json
+{
+  "status": 200,
+  "message": "Recent payments",
+  "response": [
+    {
+      "id": 1,
+      "tipo": "ABONO",
+      "valor": 200000,
+      "metodo_pago": "TRANSFERENCIA",
+      "fecha_pago": "2026-05-10"
+    }
+  ]
+}
+```
+
+### GET `/reports/sessions/summary` (prioridad baja/media)
+
+Resumen de avance de sesiones para gráfico circular.
+
+Query params:
+
+- `period`
+- `startDate`
+- `endDate`
+
+Respuesta:
+
+```json
+{
+  "status": 200,
+  "message": "Sessions summary",
+  "response": {
+    "completed": 320,
+    "pending": 40,
+    "total": 360,
+    "completionRate": 89
+  }
+}
+```
+
+### No hacer en reportes
+
+- No retornar miles de pagos, citas o paquetes para que el frontend calcule métricas.
+- No obligar al frontend a hacer `reduce`, `map`, `groupBy` o filtros complejos.
+- No reutilizar endpoints CRUD/listado masivo como fuente principal del dashboard.
+
+### Prioridad de implementación recomendada
+
+1. `GET /reports/dashboard`
+2. `GET /reports/revenue`
+3. `GET /reports/appointments/status-distribution`
+4. `GET /reports/professionals/top`
+5. `GET /reports/packages/near-completion`
+6. `GET /reports/payments/recent`
+7. Endpoints analíticos avanzados y comparativas históricas.
+
+## 7) Reglas transversales y consideraciones para un LLM
 
 1. **Autorización**: salvo login y swagger, todo exige JWT Bearer.
 2. **Respuesta envolvente**: casi todos endpoints devuelven `status/message/response`.
@@ -608,7 +1020,7 @@ Obtiene por código.
 8. **Export de historia**:
    - endpoint nombrado `export-pdf` pero entrega DOCX.
 
-## 7) Mapa rápido de endpoints
+## 8) Mapa rápido de endpoints
 
 - `POST /auth/login`
 - `GET /patient/get-patients`
@@ -619,13 +1031,16 @@ Obtiene por código.
 - `DELETE /patient/delete-patient/:id`
 - `GET /packages/get-packages`
 - `POST /packages/create`
+- `GET /packages/get-assigned`
 - `GET /packages/get-by-patient/:id`
+- `GET /packages/get-available-by-patient/:id?quoteId=...`
 - `GET /packages/get/:id`
 - `PUT /packages/close/:id`
 - `GET /quotes/all`
 - `GET /quotes/all-attention-packages`
 - `POST /quotes/create`
 - `GET /quotes/get-by-package/:id`
+- `PUT /quotes/update/:id`
 - `GET /quotes/availability/:id?date=YYYY-MM-DD`
 - `DELETE /quotes/:id`
 - `POST /history/create`
@@ -636,16 +1051,26 @@ Obtiene por código.
 - `GET /payments/:id`
 - `GET /payments/package-summary/:id`
 - `GET /payments/package-all-summary/:id`
+- `GET /payments/appointment-summary/:id`
 - `POST /payments/`
 - `PUT /payments/:id`
 - `DELETE /payments/:id`
 - `GET /professionals/get-all`
+- `GET /reports/dashboard`
+- `GET /reports/revenue`
+- `GET /reports/appointments/status-distribution`
+- `GET /reports/professionals/top`
+- `GET /reports/packages/by-type`
+- `GET /reports/packages/near-completion`
+- `GET /reports/payments/recent`
+- `GET /reports/sessions/summary`
 - `POST /cie10/create`
 - `GET /cie10/all`
 - `GET /cie10/:id`
+- `PUT /cie10/:id`
 - `GET /cie10/code/:code`
 
-## 8) Sugerencia para alimentar un LLM
+## 9) Sugerencia para alimentar un LLM
 
 Para mejor performance de RAG/LLM:
 

--- a/docs/FRONT_BACKEND_GAPS_AND_REPORTS.md
+++ b/docs/FRONT_BACKEND_GAPS_AND_REPORTS.md
@@ -1,0 +1,221 @@
+# Ajustes de documentación por comentarios frontend y módulo de reportes
+
+Este documento consolida las brechas detectadas entre pantallas frontend y contrato backend, más el requerimiento de reportes agregados. Su objetivo es dejar claro qué endpoints ya existen, cuáles requieren paginación/filtros, cuáles faltan y cómo debe evolucionar el módulo de reportes para evitar cargas masivas en cliente.
+
+## 1) Principios de compatibilidad backend/frontend
+
+- Preservar el contrato global `status`, `message`, `response`.
+- Mantener los arrays en `response` para no romper pantallas existentes.
+- Agregar metadata de paginación en una propiedad hermana `pagination`, no dentro de `response`.
+- Reutilizar helpers/modelos de paginación para que pacientes, paquetes, citas, pagos, CIE10 y profesionales tengan el mismo shape.
+- Evitar requests innecesarios: cuando una pantalla requiere resumen o conteos, exponer endpoints agregados.
+- La fuente de verdad de rutas y servicios debe estar alineada con `docs/ENDPOINTS_NEGOCIO_LLM.md`.
+
+Shape recomendado para listados paginados:
+
+```json
+{
+  "status": 200,
+  "message": "Listado consultado",
+  "response": [],
+  "pagination": {
+    "total": 0,
+    "page": 1,
+    "limit": 20,
+    "totalPages": 0,
+    "hasNextPage": false,
+    "hasPreviousPage": false
+  }
+}
+```
+
+## 2) Endpoints incompletos: ajuste aplicado
+
+| Endpoint | Problema | Ajuste backend aplicado |
+| --- | --- | --- |
+| `GET /quotes/all` | No documenta paginación, `limit`, `search`, filtros por fecha/profesional/paciente ni metadata `pagination`. | Se agregaron `page`, `limit`, `search`, `fecha`, `fechaInicio`, `fechaFin`, `id_profesional`, `id_paciente` y metadata `pagination`. Se mantiene `response` como `Appointment[]`. |
+| `GET /payments/` | No documenta paginación, búsqueda ni filtros por paquete/cita. | Se agregaron `page`, `limit`, `search`, `id_paquete`, `id_cita` y metadata `pagination`. Se mantiene `response` como `Payment[]`. |
+| `GET /cie10/all` | Soporta `q` y `codigo`, pero no documenta paginación para catálogos grandes. | Se agregaron `page`, `limit` y `pagination` manteniendo `response` como `Cie10[]`. |
+| `GET /professionals/get-all` | No documenta paginación/búsqueda; puede ser aceptable solo si el catálogo es pequeño. | Se agregaron `page`, `limit`, `search` y `pagination`. Para métricas/rankings usar endpoints de reportes. |
+| `GET /packages/get-packages` | Devuelve catálogo de tipos de paquete, no paquetes asignados. No documenta paginación para catálogos grandes. | Se mantiene como catálogo y se agregaron `page`, `limit`, `search` y `pagination` sin cambiar `response`. |
+
+## 3) Endpoints faltantes por pantalla: ajuste aplicado
+
+| Página | Endpoint faltante | Método | Motivo | Ajuste aplicado |
+| --- | --- | --- | --- | --- |
+| `PackagesPage` | `/packages/get-assigned?page=1&limit=20&search=...` o equivalente | `GET` | La pantalla lista paquetes asignados a pacientes, pero la documentación indica que `/packages/get-packages` devuelve solo catálogo de tipos de paquete. | Se creó `GET /packages/get-assigned` con filtros y paginación. |
+| `AppointmentsPage` | `/quotes/:id` | `PUT` | La pantalla permite editar citas, pero la documentación/ruta actual usa `/quotes/update/:id`. | Se agregó alias `PUT /quotes/:id` y se conserva `PUT /quotes/update/:id`. |
+| `HistoryPage` | `/history/get-by-patient/:id` | `GET` | La pantalla filtra historia por paciente; actualmente se resuelve con agregación en cliente usando citas + historias por cita. | Se creó `GET /history/get-by-patient/:id`. |
+| `Cie10Page` | `/cie10/:id` | `PUT` | La pantalla permite editar CIE10, pero docs solo documentan crear y consultar. | Se implementó actualización con normalización de `codigo`, validación de duplicados y respuesta estándar. |
+| `PaymentsPage` | `/payments/appointment-summary/:id` | `GET` | La pantalla pide resumen por cita; docs solo tienen resumen por paquete. | Se creó resumen por cita con total, abonado, saldo, estado y cantidad de abonos. |
+
+## 4) Buenas prácticas aplicadas/requeridas
+
+- Contrato backend/frontend preservado: no crear `response.data`; los arrays siguen en `response` y la metadata queda en `pagination`.
+- Reutilización: la paginación debe abstraerse en modelos/helpers para evitar shapes distintos entre módulos.
+- Menos requests innecesarios: los hooks frontend deben poder cancelar requests anteriores y usar debounce en búsquedas; backend debe responder con filtros reales.
+- Compatibilidad: métodos existentes como `patientService.getAll()` pueden seguir devolviendo solo el array para pantallas antiguas, mientras métodos nuevos tipo `getPaginated()` consumen `{ response, pagination }`.
+- Fuente de verdad: las rutas de servicios frontend deben contrastarse contra la documentación backend para pacientes, paquetes, citas, historia, pagos y CIE10.
+
+## 5) Requerimiento backend: Reports Page
+
+### Objetivo
+
+Optimizar el módulo de reportes para evitar que el frontend descargue todos los registros completos mediante:
+
+- `patientService.getAll()`
+- `packageService.getAll()`
+- `appointmentService.getAll()`
+- `paymentService.getAll()`
+- `professionalService.getAll()`
+
+El frontend solo debe consumir resúmenes y datasets ya agrupados, y limitarse a renderizar cards y gráficas.
+
+### Problema actual
+
+- Se descargan listas completas.
+- Se hacen `reduce`, `filter`, `map` y agrupaciones en frontend.
+- No hay filtros reales por periodo en backend.
+- El selector `week`, `month`, `quarter` no impacta backend.
+- Hay alto consumo de memoria y múltiples requests innecesarios.
+
+### Parámetros globales
+
+Todos los endpoints de reportes deben soportar:
+
+- `period=week|month|quarter`
+- `startDate=YYYY-MM-DD` opcional
+- `endDate=YYYY-MM-DD` opcional
+
+Si `startDate` y `endDate` están presentes, deben tener prioridad sobre `period`.
+
+## 6) Endpoints recomendados para reportes
+
+### Prioridad alta
+
+| Endpoint | Uso |
+| --- | --- |
+| `GET /reports/dashboard` | Cards KPI, resumen general, overview dashboard. |
+| `GET /reports/revenue` | Gráfica de ingresos y evolución mensual. |
+| `GET /reports/appointments/status-distribution` | Barras/progreso por estado de cita. |
+
+### Prioridad media
+
+| Endpoint | Uso |
+| --- | --- |
+| `GET /reports/professionals/top?limit=5&period=month` | Ranking de profesionales. |
+| `GET /reports/packages/by-type` | Distribución de paquetes. |
+| `GET /reports/packages/near-completion?threshold=70&limit=5` | Alertas de paquetes próximos a terminar. |
+| `GET /reports/payments/recent?limit=5` | Feed de actividad reciente. |
+
+### Prioridad baja/media
+
+| Endpoint | Uso |
+| --- | --- |
+| `GET /reports/sessions/summary` | Gráfico circular de progreso de sesiones. |
+| Endpoints analíticos avanzados | Comparativas históricas y tendencias. |
+
+## 7) Respuesta principal esperada: `GET /reports/dashboard`
+
+```json
+{
+  "status": 200,
+  "message": "Dashboard report",
+  "response": {
+    "patients": {
+      "active": 120,
+      "inactive": 15,
+      "total": 135
+    },
+    "appointments": {
+      "completed": 230,
+      "scheduled": 40,
+      "cancelled": 20,
+      "noShow": 10,
+      "attendanceRate": 88
+    },
+    "sessions": {
+      "completed": 480,
+      "pending": 120,
+      "total": 600,
+      "completionRate": 80
+    },
+    "revenue": {
+      "total": 25000000,
+      "byMonth": [
+        {
+          "month": "2026-01",
+          "amount": 5000000
+        }
+      ],
+      "byPaymentMethod": [
+        {
+          "method": "EFECTIVO",
+          "amount": 12000000
+        },
+        {
+          "method": "TRANSFERENCIA",
+          "amount": 8000000
+        }
+      ]
+    },
+    "packages": {
+      "total": 80,
+      "byType": [
+        {
+          "type": "REHABILITACION",
+          "count": 40
+        }
+      ],
+      "nearCompletion": [
+        {
+          "id": 1,
+          "nombre": "Paquete Rodilla",
+          "completionPercentage": 85,
+          "sesionesRealizadas": 17,
+          "cantidadSesiones": 20,
+          "paciente": {
+            "id": 5,
+            "nombres": "Ana",
+            "apellidos": "Perez"
+          }
+        }
+      ]
+    },
+    "professionals": {
+      "top": [
+        {
+          "id": 2,
+          "nombres": "Carlos",
+          "apellidos": "Lopez",
+          "appointments": 42
+        }
+      ]
+    },
+    "recentPayments": [
+      {
+        "id": 1,
+        "tipo": "ABONO",
+        "valor": 200000,
+        "metodo_pago": "EFECTIVO",
+        "fecha_pago": "2026-05-10T10:00:00"
+      }
+    ]
+  }
+}
+```
+
+## 8) Optimizaciones obligatorias para reportes
+
+- Usar agregaciones SQL (`COUNT`, `SUM`, `GROUP BY`, funciones de fecha) en servicios/repositorios.
+- Evitar retornar listas completas para que el frontend calcule métricas.
+- Soportar filtros por periodo y por rango de fecha explícito.
+- Optimizar joins y seleccionar solo campos necesarios.
+- Limitar feeds recientes con `limit`.
+- Validar y normalizar `period`, `startDate`, `endDate`, `limit` y `threshold`.
+
+## 9) No hacer
+
+- No retornar miles de pagos, citas o paquetes en endpoints de reportes.
+- No obligar al frontend a hacer cálculos pesados con `reduce`, `map`, `groupBy` o filtros complejos.
+- No reutilizar endpoints CRUD masivos como fuente de datos del dashboard.

--- a/src/controllers/cie10.controller.js
+++ b/src/controllers/cie10.controller.js
@@ -14,12 +14,30 @@ const getAll = async (req, res) => {
   try {
     const cie10List = await cie10Service.getAll({
       q: req.query.q,
-      codigo: req.query.codigo
+      codigo: req.query.codigo,
+      page: req.query.page,
+      limit: req.query.limit
     });
 
-    res.status(200).send(response.set(200, 'Listado CIE10', cie10List));
+    res.status(200).send(
+      response.paginated(200, 'Listado CIE10', cie10List.data, cie10List.pagination)
+    );
   } catch (error) {
     res.status(500).send(response.set(500, error.message || 'No se pudo consultar CIE10'));
+  }
+};
+
+
+const update = async (req, res) => {
+  try {
+    const cie10 = await cie10Service.update(req.params.id, req.body);
+    if (!cie10) {
+      return res.status(404).send(response.set(404, 'Código CIE10 no encontrado'));
+    }
+
+    res.status(200).send(response.set(200, 'Código CIE10 actualizado', cie10));
+  } catch (error) {
+    res.status(400).send(response.set(400, error.message || 'No se pudo actualizar el código CIE10'));
   }
 };
 
@@ -52,6 +70,7 @@ const getByCode = async (req, res) => {
 module.exports = {
   create,
   getAll,
+  update,
   getById,
   getByCode
 };

--- a/src/controllers/historyquotes.controller.js
+++ b/src/controllers/historyquotes.controller.js
@@ -107,6 +107,16 @@ module.exports = {
         }
     },
 
+
+    async getByPatient(req, res) {
+        try {
+            const histories = await historyService.getByPatient(req.params.id);
+            res.send(response.set(200, 'Historiales del paciente', histories));
+        } catch (e) {
+            res.status(400).send(response.set(500, e.message));
+        }
+    },
+
     async getSummaryByHistoryNumber(req, res) {
         try {
             const data = await historyService.getSummaryByHistoryNumber(req.params.id);

--- a/src/controllers/package.controller.js
+++ b/src/controllers/package.controller.js
@@ -70,11 +70,34 @@ module.exports = {
 
     async getAllPackages(req, res) {
         try {
-            const packages = await packagesService.getAll();
-            res.status(200).send(response.set(200, 'Consultada la informacion de los paquetes', packages));
+            const packages = await packagesService.getAll(req.query);
+            res.status(200).send(
+                response.paginated(
+                    200,
+                    'Consultada la informacion de los paquetes',
+                    packages.data,
+                    packages.pagination
+                )
+            );
 
         } catch (error) {
             res.status(400).send(response.set(error.status || 500, error.message || 'No hubo respuesta del servidor al obtener paquetes'));
+        }
+    },
+
+    async getAssignedPackages(req, res) {
+        try {
+            const packages = await packagesService.getAssigned(req.query);
+            res.status(200).send(
+                response.paginated(
+                    200,
+                    'Listado de paquetes asignados',
+                    packages.data,
+                    packages.pagination
+                )
+            );
+        } catch (error) {
+            res.status(400).send(response.set(error.status || 500, error.message || 'No hubo respuesta del servidor al obtener paquetes asignados'));
         }
     },
 

--- a/src/controllers/payment.controller.js
+++ b/src/controllers/payment.controller.js
@@ -3,8 +3,8 @@ const response = require('../models/Response.models');
 
 const getAll = async (req, res) => {
   try {
-    const result = await paymentService.getAll();
-    res.send(response.set(200, 'Listado de pagos', result));
+    const result = await paymentService.getAll(req.query);
+    res.send(response.paginated(200, 'Listado de pagos', result.data, result.pagination));
   } catch (e) {
     res.status(500).send(response.set(500, e.message));
   }
@@ -23,6 +23,16 @@ const getPackageSummary = async (req, res) => {
   try {
     const result = await paymentService.getPackageSummary(req.params.id);
     res.send(response.set(200, 'Resumen de pagos del paquete', result));
+  } catch (e) {
+    res.status(500).send(response.set(500, e.message));
+  }
+};
+
+
+const getAppointmentSummary = async (req, res) => {
+  try {
+    const result = await paymentService.getAppointmentSummary(req.params.id);
+    res.send(response.set(200, 'Resumen de pagos de la cita', result));
   } catch (e) {
     res.status(500).send(response.set(500, e.message));
   }
@@ -64,4 +74,4 @@ const deletePayment = async (req, res) => {
   }
 };
 
-module.exports = { getAll, getById, getPackageSummary,getAllPaymentsForPackage, createPayment, updatePayment, deletePayment };
+module.exports = { getAll, getById, getPackageSummary, getAppointmentSummary, getAllPaymentsForPackage, createPayment, updatePayment, deletePayment };

--- a/src/controllers/professional.controller.js
+++ b/src/controllers/professional.controller.js
@@ -1,21 +1,23 @@
-const response = require('../models/Response.models')
+const response = require('../models/Response.models');
 const professionalService = require('../services/professional.service');
 
-//Listar todos los Profesionale
+// Listar todos los profesionales
 const getAllProfessionals = async (req, res) => {
-  try{
-
-    const professionals = await professionalService.getAllProfessional();
-    res.status(200).send(response.set(200, 'Listado de Profesionales',professionals));
-
-  }catch(error){
-
+  try {
+    const professionals = await professionalService.getAllProfessional(req.query);
+    res.status(200).send(
+      response.paginated(
+        200,
+        'Listado de Profesionales',
+        professionals.data,
+        professionals.pagination
+      )
+    );
+  } catch (error) {
     res.status(400).send(response.set(error.status || 500, error.message || 'No hubo respuesta del servidor'));
-
   }
 };
 
-
-module.exports = { 
-    getAllProfessionals
-    };
+module.exports = {
+  getAllProfessionals
+};

--- a/src/controllers/quotes.controller.js
+++ b/src/controllers/quotes.controller.js
@@ -38,9 +38,9 @@ module.exports = {
     },
     async getAllQuotes(req, res) {
         try {
-            const qts = await quotesService.getAll();
+            const qts = await quotesService.getAll(req.query);
 
-            const result = qts.map(q => {
+            const result = qts.data.map(q => {
                 const pack = q.package || {};
                 const patient = pack.patient || {};
                 const professional = q.professional || {};
@@ -54,19 +54,25 @@ module.exports = {
                     numero_sesion: q.numero_sesion,
                     pagado: q.pagado,
                     motivo: q.motivo,
+                    id_profesional: q.id_profesional,
+                    id_paquetes: q.id_paquetes,
+                    id_estado_citas: q.id_estado_citas,
 
                     // 🔹 PACIENTE
                     paciente: `${patient.nombre || ''} ${patient.apellido || ''}`.trim(),
+                    id_paciente: patient.id || null,
+                    num_doc_paciente: patient.num_doc || null,
 
                     // 🔹 PROFESIONAL
                     profesional: professional.nombre || null,
+                    apellido_profesional: professional.apellido || null,
 
                     // 🔹 ESTADO
                     estado: status.nombre || null
                 };
             });
 
-            res.send(response.set(200, "Citas", result));
+            res.send(response.paginated(200, 'Citas', result, qts.pagination));
 
         } catch (err) {
             res.status(400).send(response.set(500, err.message));

--- a/src/controllers/report.controller.js
+++ b/src/controllers/report.controller.js
@@ -1,0 +1,33 @@
+const response = require('../models/Response.models');
+const reportService = require('../services/report.service');
+
+const getFilters = (req) => ({
+  period: req.query.period,
+  startDate: req.query.startDate,
+  endDate: req.query.endDate,
+  limit: req.query.limit,
+  threshold: req.query.threshold
+});
+
+const handleReport = (serviceMethod, message) => async (req, res) => {
+  try {
+    const result = await serviceMethod(getFilters(req));
+    res.status(200).send(response.set(200, message, result));
+  } catch (error) {
+    res.status(500).send(response.set(500, error.message || 'No se pudo consultar el reporte'));
+  }
+};
+
+module.exports = {
+  getDashboard: handleReport(reportService.getDashboard, 'Dashboard report'),
+  getRevenue: handleReport(reportService.getRevenue, 'Revenue report'),
+  getAppointmentStatusDistribution: handleReport(
+    reportService.getAppointmentStatusDistribution,
+    'Appointment status distribution'
+  ),
+  getTopProfessionals: handleReport(reportService.getTopProfessionals, 'Top professionals'),
+  getPackagesByType: handleReport(reportService.getPackagesByType, 'Packages by type'),
+  getPackagesNearCompletion: handleReport(reportService.getPackagesNearCompletion, 'Packages near completion'),
+  getRecentPayments: handleReport(reportService.getRecentPayments, 'Recent payments'),
+  getSessionsSummary: handleReport(reportService.getSessionsSummary, 'Sessions summary')
+};

--- a/src/routes.js
+++ b/src/routes.js
@@ -11,6 +11,7 @@ const historyquotes = require('./routes/historyquote.route');
 const paymentsRoutes = require('./routes/payment.route');
 const professionalRoutes = require('./routes/professional.route');
 const cie10Routes = require('./routes/cie10.route');
+const reportRoutes = require('./routes/report.route');
 
 //Cargamos el swagger 
 const swaggerUi = require('swagger-ui-express');
@@ -61,4 +62,5 @@ app.use('/history',historyquotes);
 app.use('/payments', paymentsRoutes);
 app.use('/professionals', professionalRoutes);
 app.use('/cie10', cie10Routes);
+app.use('/reports', reportRoutes);
 module.exports = app;

--- a/src/routes/cie10.route.js
+++ b/src/routes/cie10.route.js
@@ -5,6 +5,7 @@ const router = express.Router();
 
 router.post('/create', cie10Controller.create);
 router.get('/all', cie10Controller.getAll);
+router.put('/:id', cie10Controller.update);
 router.get('/code/:code', cie10Controller.getByCode);
 router.get('/:id', cie10Controller.getById);
 

--- a/src/routes/historyquote.route.js
+++ b/src/routes/historyquote.route.js
@@ -9,6 +9,7 @@ router.post('/create', historyController.create);
 router.put('/update/:id', historyController.update);
 router.get('/export-pdf/:id', historyController.exportPdf);
 router.get('/get-by-quote/:id', historyController.getByQuote);
+router.get('/get-by-patient/:id', historyController.getByPatient);
 router.get('/get-summary-by-history-number/:id', historyController.getSummaryByHistoryNumber);
 router.get('/get-summary-by-quote-number/:id', historyController.getSummaryByQuoteNumber);
 router.delete('/delete-quote/:id', historyController.deleteQuote);

--- a/src/routes/packages.route.js
+++ b/src/routes/packages.route.js
@@ -11,6 +11,7 @@ const { verifyToken } = require('../middlewares/auth.middleware');
 // router.delete('/delete-package/:id', packageController.deletePackage);
 
 router.post('/create', packagesController.createPackage);
+router.get('/get-assigned', packagesController.getAssignedPackages);
 router.get('/get-by-patient/:id', packagesController.getPackagesByPatient);
 router.get('/get-available-by-patient/:id', packagesController.getAvailablePackagesByPatient);
 router.get('/get-packages', packagesController.getAllPackages);

--- a/src/routes/payment.route.js
+++ b/src/routes/payment.route.js
@@ -8,6 +8,7 @@ const { verifyToken } = require('../middlewares/auth.middleware');
 router.get('/', paymentController.getAll);
 router.get('/package-summary/:id', paymentController.getPackageSummary);
 router.get('/package-all-summary/:id', paymentController.getAllPaymentsForPackage);
+router.get('/appointment-summary/:id', paymentController.getAppointmentSummary);
 router.get('/:id', paymentController.getById);
 router.post('/', paymentController.createPayment);
 router.put('/:id', paymentController.updatePayment);

--- a/src/routes/quotes.route.js
+++ b/src/routes/quotes.route.js
@@ -22,6 +22,7 @@ router.get('/all', quotesController.getAllQuotes);
 router.get('/all-attention-packages', quotesController.getAllAttentionPackages);
 router.post('/create', quotesController.createQuote);
 router.put('/update/:id', quotesController.updateQuote);
+router.put('/:id', quotesController.updateQuote);
 router.get('/get-by-package/:id', quotesController.getQuotesByPackage);
 router.get('/availability/:id', quotesController.getAvailability); // ?date=YYYY-MM-DD
 router.delete('/:id', quotesController.deleteQuote);

--- a/src/routes/report.route.js
+++ b/src/routes/report.route.js
@@ -1,0 +1,15 @@
+const express = require('express');
+const reportController = require('../controllers/report.controller');
+
+const router = express.Router();
+
+router.get('/dashboard', reportController.getDashboard);
+router.get('/revenue', reportController.getRevenue);
+router.get('/appointments/status-distribution', reportController.getAppointmentStatusDistribution);
+router.get('/professionals/top', reportController.getTopProfessionals);
+router.get('/packages/by-type', reportController.getPackagesByType);
+router.get('/packages/near-completion', reportController.getPackagesNearCompletion);
+router.get('/payments/recent', reportController.getRecentPayments);
+router.get('/sessions/summary', reportController.getSessionsSummary);
+
+module.exports = router;

--- a/src/services/cie10.service.js
+++ b/src/services/cie10.service.js
@@ -1,5 +1,6 @@
 const { Op } = require('sequelize');
 const { Cie10 } = require('../models');
+const Pagination = require('../models/Pagination.models');
 
 const normalizeCode = (value) => String(value || '').trim().toUpperCase();
 
@@ -19,7 +20,7 @@ const create = async (data) => {
   return Cie10.create({ codigo, descripcion });
 };
 
-const getAll = async ({ q, codigo } = {}) => {
+const getAll = async ({ q, codigo, page = 1, limit = 20 } = {}) => {
   const where = {};
 
   if (codigo) {
@@ -33,16 +34,68 @@ const getAll = async ({ q, codigo } = {}) => {
     ];
   }
 
-  return Cie10.findAll({ where, order: [['codigo', 'ASC']] });
+  const { page: normalizedPage, limit: normalizedLimit } = Pagination.normalize({ page, limit });
+  const offset = (normalizedPage - 1) * normalizedLimit;
+
+  const { rows, count } = await Cie10.findAndCountAll({
+    where,
+    limit: normalizedLimit,
+    offset,
+    order: [['codigo', 'ASC']]
+  });
+
+  return {
+    data: rows,
+    pagination: Pagination.set({
+      total: count,
+      page: normalizedPage,
+      limit: normalizedLimit
+    })
+  };
 };
 
 const getById = async (id) => Cie10.findByPk(id);
 
 const getByCode = async (codigo) => Cie10.findOne({ where: { codigo: normalizeCode(codigo) } });
 
+const update = async (id, data) => {
+  const cie10 = await Cie10.findByPk(id);
+  if (!cie10) return null;
+
+  const payload = {};
+
+  if (Object.prototype.hasOwnProperty.call(data, 'codigo')) {
+    const codigo = normalizeCode(data.codigo);
+    if (!codigo) throw new Error('codigo es obligatorio');
+
+    const existing = await Cie10.findOne({
+      where: {
+        codigo,
+        id: { [Op.ne]: id }
+      }
+    });
+
+    if (existing) {
+      throw new Error('El código CIE10 ya existe');
+    }
+
+    payload.codigo = codigo;
+  }
+
+  if (Object.prototype.hasOwnProperty.call(data, 'descripcion')) {
+    const descripcion = String(data.descripcion || '').trim();
+    if (!descripcion) throw new Error('descripcion es obligatoria');
+    payload.descripcion = descripcion;
+  }
+
+  await cie10.update(payload);
+  return cie10;
+};
+
 module.exports = {
   create,
   getAll,
+  update,
   getById,
   getByCode
 };

--- a/src/services/historyquotes.service.js
+++ b/src/services/historyquotes.service.js
@@ -410,8 +410,11 @@ module.exports = {
                             model: Patient,
                             as: 'patient',
                             attributes: [
+                                'id',
                                 'tipo_doc',
                                 'num_doc',
+                                'nombre',
+                                'apellido',
                                 'telefono',
                                 'telefono_secundario',
                                 'email',
@@ -438,6 +441,35 @@ module.exports = {
                     ]
                 }
             ]
+        });
+    },
+
+
+    async getByPatient(id_paciente) {
+        return await HistoryQuote.findAll({
+            include: [
+                { model: Cie10, as: 'Cie10', attributes: ['id', 'codigo', 'descripcion'] },
+                {
+                    model: Quotes,
+                    as: 'Quotes',
+                    attributes: ['id', 'fecha_agendamiento', 'horario_inicio', 'motivo', 'numero_sesion', 'id_profesional', 'id_paquetes'],
+                    required: true,
+                    include: [
+                        {
+                            model: Packages,
+                            as: 'package',
+                            attributes: ['id', 'id_pacientes', 'id_paquetes_atenciones'],
+                            where: { id_pacientes: id_paciente },
+                            required: true,
+                            include: [
+                                { model: Patient, as: 'patient', attributes: ['id', 'nombre', 'apellido', 'num_doc'] },
+                                { model: AttentionPackages, as: 'attentionPackage', attributes: ['id', 'descripcion'] }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            order: [['fecha_evolucion', 'DESC'], ['id', 'DESC']]
         });
     },
 

--- a/src/services/packages.service.js
+++ b/src/services/packages.service.js
@@ -1,4 +1,6 @@
+const { Op } = require('sequelize');
 const { Packages, AttentionPackages, Quotes, Patient, StatusPackages, Professional, Cie10, sequelize } = require('../models');
+const Pagination = require('../models/Pagination.models');
 
 module.exports = {
 
@@ -29,8 +31,80 @@ module.exports = {
         return await Packages.create(data);
     },
 
-    async getAll() {
-        return await AttentionPackages.findAll({});
+    async getAll({ page = 1, limit = 20, search = '' } = {}) {
+        const { page: normalizedPage, limit: normalizedLimit } = Pagination.normalize({ page, limit });
+        const offset = (normalizedPage - 1) * normalizedLimit;
+        const where = {};
+
+        if (search && search.trim() !== '') {
+            where.descripcion = { [Op.iLike]: `%${search.trim()}%` };
+        }
+
+        const { rows, count } = await AttentionPackages.findAndCountAll({
+            where,
+            limit: normalizedLimit,
+            offset,
+            order: [['descripcion', 'ASC']]
+        });
+
+        return {
+            data: rows,
+            pagination: Pagination.set({
+                total: count,
+                page: normalizedPage,
+                limit: normalizedLimit
+            })
+        };
+    },
+
+    async getAssigned({ page = 1, limit = 20, search = '', id_paciente, id_profesional, id_estado_citas } = {}) {
+        const { page: normalizedPage, limit: normalizedLimit } = Pagination.normalize({ page, limit });
+        const offset = (normalizedPage - 1) * normalizedLimit;
+        const where = {};
+
+        if (id_paciente) where.id_pacientes = id_paciente;
+        if (id_profesional) where.id_profesional = id_profesional;
+        if (id_estado_citas) where.id_estado_citas = id_estado_citas;
+
+        if (search && search.trim() !== '') {
+            const value = `%${search.trim()}%`;
+            where[Op.or] = [
+                { '$patient.nombre$': { [Op.iLike]: value } },
+                { '$patient.apellido$': { [Op.iLike]: value } },
+                { '$patient.num_doc$': { [Op.iLike]: value } },
+                { '$attentionPackage.descripcion$': { [Op.iLike]: value } },
+                { '$professional.nombre$': { [Op.iLike]: value } },
+                { '$professional.apellido$': { [Op.iLike]: value } }
+            ];
+        }
+
+        const include = [
+            { model: Patient, as: 'patient', attributes: ['id', 'nombre', 'apellido', 'num_doc'] },
+            { model: AttentionPackages, as: 'attentionPackage' },
+            { model: StatusPackages, as: 'statusPackage' },
+            { model: Professional, as: 'professional', attributes: ['id', 'nombre', 'apellido'] },
+            { model: Cie10, as: 'secondaryDiagnosis', attributes: ['id', 'codigo', 'descripcion'] },
+            { model: Quotes, attributes: ['id', 'fecha_agendamiento', 'numero_sesion', 'id_estado_citas'] }
+        ];
+
+        const { rows, count } = await Packages.findAndCountAll({
+            where,
+            include,
+            limit: normalizedLimit,
+            offset,
+            distinct: true,
+            subQuery: false,
+            order: [['id', 'DESC']]
+        });
+
+        return {
+            data: rows,
+            pagination: Pagination.set({
+                total: count,
+                page: normalizedPage,
+                limit: normalizedLimit
+            })
+        };
     },
     async getByPatient(id_pacientes) {
         return await Packages.findAll({

--- a/src/services/payment.service.js
+++ b/src/services/payment.service.js
@@ -1,4 +1,6 @@
+const { Op } = require('sequelize');
 const { Payment, Quotes, Packages, AttentionPackages, sequelize } = require('../models');
+const Pagination = require('../models/Pagination.models');
 
 const sumPaymentValues = (rows) =>
   rows.reduce((acc, row) => acc + Number(row.valor || 0), 0);
@@ -149,12 +151,87 @@ const createPayment = async (data) => {
 /**
  * CRUD básicos
  */
-const getAll = async () => Payment.findAll();
+const getAll = async ({ page = 1, limit = 20, search = '', id_paquete, id_cita } = {}) => {
+  const { page: normalizedPage, limit: normalizedLimit } = Pagination.normalize({ page, limit });
+  const offset = (normalizedPage - 1) * normalizedLimit;
+  const where = {};
+
+  if (id_paquete) where.id_paquete = id_paquete;
+  if (id_cita) where.id_cita = id_cita;
+
+  if (search && search.trim() !== '') {
+    const value = `%${search.trim()}%`;
+    where[Op.or] = [
+      { metodo_pago: { [Op.iLike]: value } },
+      { tipo: { [Op.iLike]: value } },
+      { observacion: { [Op.iLike]: value } }
+    ];
+  }
+
+  const { rows, count } = await Payment.findAndCountAll({
+    where,
+    limit: normalizedLimit,
+    offset,
+    order: [['fecha_pago', 'DESC']]
+  });
+
+  return {
+    data: rows,
+    pagination: Pagination.set({
+      total: count,
+      page: normalizedPage,
+      limit: normalizedLimit
+    })
+  };
+};
 
 const getById = async (id) => Payment.findByPk(id);
 
 const getPackageSummary = async (id_paquete) =>
   getPackagePaymentSummary(id_paquete);
+
+const getAppointmentSummary = async (id_cita) => {
+  const quote = await Quotes.findByPk(id_cita, {
+    include: [
+      {
+        model: Packages,
+        as: 'package',
+        include: [{ model: AttentionPackages, as: 'attentionPackage' }]
+      }
+    ]
+  });
+  if (!quote) {
+    throw new Error('Cita no encontrada');
+  }
+
+  const payments = await Payment.findAll({
+    where: { id_cita, tipo: 'cita' }
+  });
+
+  const totalAbonado = sumPaymentValues(payments);
+  const packageValue = Number(quote.package?.attentionPackage?.valor || 0);
+  const sessionCount = Number(quote.package?.attentionPackage?.cantidad_sesiones || 0);
+  const totalCita = sessionCount > 0 ? Math.round(packageValue / sessionCount) : totalAbonado;
+  const saldoPendiente = Math.max(totalCita - totalAbonado, 0);
+
+  let estadoPago = 'pendiente';
+  if (totalCita > 0 && totalAbonado >= totalCita) {
+    estadoPago = 'pagado';
+  } else if (totalAbonado > 0) {
+    estadoPago = 'abonado';
+  } else if (quote.pagado) {
+    estadoPago = 'pagado';
+  }
+
+  return {
+    id_cita,
+    total_cita: totalCita,
+    total_abonado: totalAbonado,
+    saldo_pendiente: saldoPendiente,
+    estado_pago: estadoPago,
+    cantidad_abonos: payments.length
+  };
+};
 
 const updatePayment = async (id, data) => {
   await Payment.update(data, { where: { id } });
@@ -169,6 +246,7 @@ module.exports = {
   getAll,
   getById,
   getPackageSummary,
+  getAppointmentSummary,
   getAllPaymentsForPackage,
   updatePayment,
   deletePayment

--- a/src/services/professional.service.js
+++ b/src/services/professional.service.js
@@ -1,9 +1,39 @@
-const { Patient, Professional } = require('../models');
+const { Op } = require('sequelize');
+const { Professional } = require('../models');
+const Pagination = require('../models/Pagination.models');
 
-const getAllProfessional = async () => {
-  return await Professional.findAll();
-}
+const getAllProfessional = async ({ page = 1, limit = 20, search = '' } = {}) => {
+  const { page: normalizedPage, limit: normalizedLimit } = Pagination.normalize({ page, limit });
+  const offset = (normalizedPage - 1) * normalizedLimit;
+  const where = {};
+
+  if (search && search.trim() !== '') {
+    const value = `%${search.trim()}%`;
+    where[Op.or] = [
+      { nombre: { [Op.iLike]: value } },
+      { apellido: { [Op.iLike]: value } },
+      { especialidad: { [Op.iLike]: value } },
+      { email: { [Op.iLike]: value } }
+    ];
+  }
+
+  const { rows, count } = await Professional.findAndCountAll({
+    where,
+    limit: normalizedLimit,
+    offset,
+    order: [['nombre', 'ASC']],
+  });
+
+  return {
+    data: rows,
+    pagination: Pagination.set({
+      total: count,
+      page: normalizedPage,
+      limit: normalizedLimit
+    })
+  };
+};
 
 module.exports = {
   getAllProfessional
-}
+};

--- a/src/services/quotes.service.js
+++ b/src/services/quotes.service.js
@@ -1,4 +1,6 @@
+const { Op } = require('sequelize');
 const { Quotes, Packages, AttentionPackages, Patient, Professional, StatusQuotes } = require('../models');
+const Pagination = require('../models/Pagination.models');
 
 module.exports = {
 
@@ -59,32 +61,91 @@ module.exports = {
         return await Quotes.create(data);
     },
 
-    async getAll() {
-        return await Quotes.findAll({
-            include: [
-                {
-                    model: Packages,
-                    as: 'package',
-                    include: [
-                        {
-                            model: Patient,
-                            as: 'patient',
-                            attributes: ['nombre', 'apellido']
-                        }
-                    ]
-                },
-                {
-                    model: Professional,
-                    as: 'professional',
-                    attributes: ['nombre']
-                },
-                {
-                    model: StatusQuotes,
-                    as: 'status',
-                    attributes: ['nombre']
-                }
-            ]
+    async getAll({
+        page = 1,
+        limit = 20,
+        search = '',
+        fecha,
+        fechaInicio,
+        fechaFin,
+        id_profesional,
+        id_paciente
+    } = {}) {
+        const { page: normalizedPage, limit: normalizedLimit } = Pagination.normalize({ page, limit });
+        const offset = (normalizedPage - 1) * normalizedLimit;
+        const where = {};
+        const packageWhere = {};
+
+        if (fecha) {
+            where.fecha_agendamiento = fecha;
+        } else if (fechaInicio && fechaFin) {
+            where.fecha_agendamiento = { [Op.between]: [fechaInicio, fechaFin] };
+        }
+
+        if (id_profesional) {
+            where.id_profesional = id_profesional;
+        }
+
+        if (id_paciente) {
+            packageWhere.id_pacientes = id_paciente;
+        }
+
+        if (search && search.trim() !== '') {
+            const value = `%${search.trim()}%`;
+            where[Op.or] = [
+                { motivo: { [Op.iLike]: value } },
+                { '$professional.nombre$': { [Op.iLike]: value } },
+                { '$professional.apellido$': { [Op.iLike]: value } },
+                { '$package.patient.nombre$': { [Op.iLike]: value } },
+                { '$package.patient.apellido$': { [Op.iLike]: value } },
+                { '$package.patient.num_doc$': { [Op.iLike]: value } }
+            ];
+        }
+
+        const include = [
+            {
+                model: Packages,
+                as: 'package',
+                required: Boolean(id_paciente),
+                where: packageWhere,
+                include: [
+                    {
+                        model: Patient,
+                        as: 'patient',
+                        attributes: ['id', 'nombre', 'apellido', 'num_doc']
+                    }
+                ]
+            },
+            {
+                model: Professional,
+                as: 'professional',
+                attributes: ['id', 'nombre', 'apellido']
+            },
+            {
+                model: StatusQuotes,
+                as: 'status',
+                attributes: ['id', 'nombre']
+            }
+        ];
+
+        const { rows, count } = await Quotes.findAndCountAll({
+            where,
+            include,
+            limit: normalizedLimit,
+            offset,
+            distinct: true,
+            subQuery: false,
+            order: [['fecha_agendamiento', 'DESC'], ['horario_inicio', 'ASC']]
         });
+
+        return {
+            data: rows,
+            pagination: Pagination.set({
+                total: count,
+                page: normalizedPage,
+                limit: normalizedLimit
+            })
+        };
     },
     async getAllAttentionPackages() {
         return await AttentionPackages.findAll();

--- a/src/services/report.service.js
+++ b/src/services/report.service.js
@@ -1,0 +1,398 @@
+const { Op, fn, col, literal } = require('sequelize');
+const {
+  Patient,
+  Packages,
+  AttentionPackages,
+  Quotes,
+  StatusQuotes,
+  Professional,
+  Payment
+} = require('../models');
+
+const VALID_PERIODS = ['week', 'month', 'quarter'];
+
+const startOfDay = (date) => {
+  const result = new Date(date);
+  result.setHours(0, 0, 0, 0);
+  return result;
+};
+
+const endOfDay = (date) => {
+  const result = new Date(date);
+  result.setHours(23, 59, 59, 999);
+  return result;
+};
+
+const toDateOnly = (date) => date.toISOString().slice(0, 10);
+
+const parseLimit = (value, fallback = 5, max = 100) => {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isInteger(parsed) || parsed <= 0) return fallback;
+  return Math.min(parsed, max);
+};
+
+const normalizeThreshold = (value, fallback = 70) => {
+  const parsed = Number.parseFloat(value);
+  if (!Number.isFinite(parsed) || parsed < 0) return fallback;
+  return Math.min(parsed, 100);
+};
+
+const getDateRange = ({ period = 'month', startDate, endDate } = {}) => {
+  const now = new Date();
+  let start;
+  let end;
+
+  if (startDate && endDate) {
+    start = startOfDay(`${startDate}T00:00:00`);
+    end = endOfDay(`${endDate}T00:00:00`);
+  } else {
+    end = endOfDay(now);
+    start = startOfDay(now);
+
+    const normalizedPeriod = VALID_PERIODS.includes(period) ? period : 'month';
+
+    if (normalizedPeriod === 'week') {
+      start.setDate(start.getDate() - 6);
+    } else if (normalizedPeriod === 'quarter') {
+      start.setMonth(start.getMonth() - 2, 1);
+    } else {
+      start.setDate(1);
+    }
+  }
+
+  return {
+    start,
+    end,
+    dateOnlyWhere: {
+      [Op.between]: [toDateOnly(start), toDateOnly(end)]
+    },
+    dateTimeWhere: {
+      [Op.between]: [start, end]
+    }
+  };
+};
+
+const getStatusKey = (statusName = '') => {
+  const value = statusName.toLowerCase();
+
+  if (value.includes('cancel')) return 'cancelled';
+  if (value.includes('no') && (value.includes('show') || value.includes('asist'))) return 'noShow';
+  if (value.includes('complet') || value.includes('realiz') || value.includes('atendid')) return 'completed';
+
+  return 'scheduled';
+};
+
+const getAppointmentStatusDistribution = async (filters = {}) => {
+  const range = getDateRange(filters);
+
+  const rows = await Quotes.findAll({
+    attributes: [
+      [col('status.nombre'), 'statusName'],
+      [fn('COUNT', col('Quotes.id')), 'count']
+    ],
+    include: [
+      {
+        model: StatusQuotes,
+        as: 'status',
+        attributes: []
+      }
+    ],
+    where: {
+      fecha_agendamiento: range.dateOnlyWhere
+    },
+    group: ['status.id', 'status.nombre'],
+    raw: true
+  });
+
+  return rows.reduce(
+    (acc, row) => {
+      const key = getStatusKey(row.statusName);
+      acc[key] += Number(row.count || 0);
+      return acc;
+    },
+    { completed: 0, scheduled: 0, cancelled: 0, noShow: 0 }
+  );
+};
+
+const getRevenue = async (filters = {}) => {
+  const range = getDateRange(filters);
+
+  const monthExpression = fn('to_char', col('fecha_pago'), 'YYYY-MM');
+
+  const rows = await Payment.findAll({
+    attributes: [
+      [monthExpression, 'month'],
+      [fn('COALESCE', fn('SUM', col('valor')), 0), 'amount']
+    ],
+    where: {
+      fecha_pago: range.dateTimeWhere
+    },
+    group: [monthExpression],
+    order: [[literal('month'), 'ASC']],
+    raw: true
+  });
+
+  return rows.map((row) => ({
+    month: row.month,
+    amount: Number(row.amount || 0)
+  }));
+};
+
+const getRevenueByPaymentMethod = async (filters = {}) => {
+  const range = getDateRange(filters);
+
+  const rows = await Payment.findAll({
+    attributes: [
+      ['metodo_pago', 'method'],
+      [fn('COALESCE', fn('SUM', col('valor')), 0), 'amount']
+    ],
+    where: {
+      fecha_pago: range.dateTimeWhere
+    },
+    group: ['metodo_pago'],
+    order: [[literal('amount'), 'DESC']],
+    raw: true
+  });
+
+  return rows.map((row) => ({
+    method: row.method,
+    amount: Number(row.amount || 0)
+  }));
+};
+
+const getPackagesByType = async () => {
+  const rows = await Packages.findAll({
+    attributes: [
+      [col('attentionPackage.descripcion'), 'type'],
+      [fn('COUNT', col('Packages.id')), 'count']
+    ],
+    include: [
+      {
+        model: AttentionPackages,
+        as: 'attentionPackage',
+        attributes: []
+      }
+    ],
+    group: ['attentionPackage.id', 'attentionPackage.descripcion'],
+    order: [[literal('count'), 'DESC']],
+    raw: true
+  });
+
+  return rows.map((row) => ({
+    type: row.type,
+    count: Number(row.count || 0)
+  }));
+};
+
+const getPackagesNearCompletion = async ({ threshold = 70, limit = 5 } = {}) => {
+  const normalizedThreshold = normalizeThreshold(threshold);
+  const normalizedLimit = parseLimit(limit);
+
+  const packages = await Packages.findAll({
+    include: [
+      {
+        model: AttentionPackages,
+        as: 'attentionPackage',
+        attributes: ['descripcion', 'cantidad_sesiones']
+      },
+      {
+        model: Patient,
+        as: 'patient',
+        attributes: ['id', 'nombre', 'apellido']
+      },
+      {
+        model: Quotes,
+        attributes: ['id']
+      }
+    ]
+  });
+
+  return packages
+    .map((pkg) => {
+      const cantidadSesiones = Number(pkg.attentionPackage?.cantidad_sesiones || 0);
+      const sesionesRealizadas = Number(pkg.Quotes?.length || 0);
+      const completionPercentage = cantidadSesiones > 0
+        ? Math.round((sesionesRealizadas / cantidadSesiones) * 100)
+        : 0;
+
+      return {
+        id: pkg.id,
+        nombre: pkg.attentionPackage?.descripcion || `Paquete ${pkg.id}`,
+        completionPercentage,
+        sesionesRealizadas,
+        cantidadSesiones,
+        paciente: pkg.patient
+          ? {
+              id: pkg.patient.id,
+              nombres: pkg.patient.nombre,
+              apellidos: pkg.patient.apellido
+            }
+          : null
+      };
+    })
+    .filter((pkg) => pkg.completionPercentage >= normalizedThreshold)
+    .sort((a, b) => b.completionPercentage - a.completionPercentage)
+    .slice(0, normalizedLimit);
+};
+
+const getTopProfessionals = async ({ limit = 5, ...filters } = {}) => {
+  const range = getDateRange(filters);
+  const normalizedLimit = parseLimit(limit);
+
+  const rows = await Quotes.findAll({
+    attributes: [
+      [col('professional.id'), 'id'],
+      [col('professional.nombre'), 'nombres'],
+      [col('professional.apellido'), 'apellidos'],
+      [fn('COUNT', col('Quotes.id')), 'appointments']
+    ],
+    include: [
+      {
+        model: Professional,
+        as: 'professional',
+        attributes: []
+      }
+    ],
+    where: {
+      fecha_agendamiento: range.dateOnlyWhere
+    },
+    group: ['professional.id', 'professional.nombre', 'professional.apellido'],
+    order: [[literal('appointments'), 'DESC']],
+    limit: normalizedLimit,
+    raw: true
+  });
+
+  return rows.map((row) => ({
+    id: row.id,
+    nombres: row.nombres,
+    apellidos: row.apellidos,
+    appointments: Number(row.appointments || 0)
+  }));
+};
+
+const getRecentPayments = async ({ limit = 5, ...filters } = {}) => {
+  const range = getDateRange(filters);
+  const normalizedLimit = parseLimit(limit);
+
+  return Payment.findAll({
+    where: {
+      fecha_pago: range.dateTimeWhere
+    },
+    attributes: ['id', 'tipo', 'valor', 'metodo_pago', 'fecha_pago'],
+    order: [['fecha_pago', 'DESC']],
+    limit: normalizedLimit
+  });
+};
+
+const getSessionsSummary = async (filters = {}) => {
+  const range = getDateRange(filters);
+
+  const completed = await Quotes.count({
+    where: {
+      fecha_agendamiento: range.dateOnlyWhere
+    }
+  });
+
+  const packages = await Packages.findAll({
+    include: [
+      {
+        model: AttentionPackages,
+        as: 'attentionPackage',
+        attributes: ['cantidad_sesiones']
+      },
+      {
+        model: Quotes,
+        attributes: ['id']
+      }
+    ]
+  });
+
+  const total = packages.reduce(
+    (acc, pkg) => acc + Number(pkg.attentionPackage?.cantidad_sesiones || 0),
+    0
+  );
+  const pending = Math.max(total - completed, 0);
+  const completionRate = total > 0 ? Math.round((completed / total) * 100) : 0;
+
+  return {
+    completed,
+    pending,
+    total,
+    completionRate
+  };
+};
+
+const getPatientsSummary = async () => {
+  const active = await Patient.count({ where: { estado: true } });
+  const inactive = await Patient.count({ where: { estado: false } });
+
+  return {
+    active,
+    inactive,
+    total: active + inactive
+  };
+};
+
+const getDashboard = async (filters = {}) => {
+  const [
+    patients,
+    appointments,
+    sessions,
+    revenueByMonth,
+    revenueByPaymentMethod,
+    packagesByType,
+    packagesNearCompletion,
+    topProfessionals,
+    recentPayments
+  ] = await Promise.all([
+    getPatientsSummary(filters),
+    getAppointmentStatusDistribution(filters),
+    getSessionsSummary(filters),
+    getRevenue(filters),
+    getRevenueByPaymentMethod(filters),
+    getPackagesByType(filters),
+    getPackagesNearCompletion({ ...filters, threshold: filters.threshold || 70, limit: filters.limit || 5 }),
+    getTopProfessionals({ ...filters, limit: filters.limit || 5 }),
+    getRecentPayments({ ...filters, limit: filters.limit || 5 })
+  ]);
+
+  const appointmentTotal = Object.values(appointments).reduce((acc, value) => acc + value, 0);
+  const attendanceRate = appointmentTotal > 0
+    ? Math.round((appointments.completed / appointmentTotal) * 100)
+    : 0;
+  const revenueTotal = revenueByMonth.reduce((acc, item) => acc + item.amount, 0);
+
+  return {
+    patients,
+    appointments: {
+      ...appointments,
+      attendanceRate
+    },
+    sessions,
+    revenue: {
+      total: revenueTotal,
+      byMonth: revenueByMonth,
+      byPaymentMethod: revenueByPaymentMethod
+    },
+    packages: {
+      total: await Packages.count(),
+      byType: packagesByType,
+      nearCompletion: packagesNearCompletion
+    },
+    professionals: {
+      top: topProfessionals
+    },
+    recentPayments
+  };
+};
+
+module.exports = {
+  getDashboard,
+  getRevenue,
+  getAppointmentStatusDistribution,
+  getTopProfessionals,
+  getPackagesByType,
+  getPackagesNearCompletion,
+  getRecentPayments,
+  getSessionsSummary
+};


### PR DESCRIPTION
### Motivation

- Centralizar agregaciones y métricas en el backend para la nueva Reports Page y evitar cálculos pesados en el frontend usando `GET /reports/*` endpoints. 
- Evitar transferir colecciones completas a la UI añadiendo paginación y filtros a listados pesados como `quotes`, `payments`, `cie10`, `packages` y `professionals`.
- Cubrir brechas detectadas por frontend con endpoints compatibles y alias de rutas para minimizar cambios en cliente.

### Description

- Nuevo módulo de reportes: added `src/controllers/report.controller.js`, `src/services/report.service.js` y `src/routes/report.route.js`, y se montó en `src/routes.js` bajo `/reports` con endpoints como `GET /reports/dashboard`, `GET /reports/revenue`, `GET /reports/appointments/status-distribution`, `GET /reports/professionals/top`, `GET /reports/packages/*`, `GET /reports/payments/recent` y `GET /reports/sessions/summary`.
- Paginación y búsquedas: introduced `Pagination.models` usage and added `page/limit/search` handling to services and controllers for `quotes` (`src/services/quotes.service.js`, `src/controllers/quotes.controller.js`), `payments` (`src/services/payment.service.js`, `src/controllers/payment.controller.js`), `cie10` (`src/services/cie10.service.js`, `src/controllers/cie10.controller.js`), `packages` (`src/services/packages.service.js`, `src/controllers/package.controller.js`) and `professional` (`src/services/professional.service.js`, `src/controllers/professional.controller.js`), returning paginated responses via `response.paginated` while keeping `response` arrays compatible for frontend.
- New / adjusted endpoints to close frontend gaps: added `GET /packages/get-assigned` (`packages.controller` + route), `GET /history/get-by-patient/:id` (history controller/service), `GET /payments/appointment-summary/:id` (payment controller/service), `PUT /cie10/:id` (controller + service update with normalization/duplicate checks), alias `PUT /quotes/:id` (route) and preserved compatibility of existing routes.
- Data-shape and response contract: controllers now surface pagination metadata in `pagination` sibling property and keep the global `status/message/response` envelope as documented; README and `docs/ENDPOINTS_NEGOCIO_LLM.md` were updated and a new `docs/FRONT_BACKEND_GAPS_AND_REPORTS.md` was added describing compatibility and the new report requirements.
- Minor fixes and improvements: various query includes and attributes tightened for history/quotes/packages to reduce payload and enable filters (e.g. `historyquotes.service.getByPatient`, `quotes.service` search filters and joins).

### Testing

- No automated tests were executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00c462596c8320a56c1a52e9ee54c9)